### PR TITLE
Use inherits() when checking classes (renderPlot() now includes an additional class)

### DIFF
--- a/tests/testthat/test-shiny.R
+++ b/tests/testthat/test-shiny.R
@@ -42,5 +42,5 @@ test_that("renderPlot args are as required", {
     plot(1:10)
   }, height = 100, units = "px", res = 72)
 
-  expect_identical(class(d), c("shiny.render.function", "function"))
+  expect_true(inherits(d, c("shiny.render.function", "function")))
 })


### PR DESCRIPTION
In the next version of shiny (which we plan on submitting to CRAN in a week or so), `renderPlot()` now includes an additional `shiny.renderPlot` class, which means this unit test will now fail. 

This change makes it so your unit tests will continue to pass with the new version. 

Let me know if you have any questions and please submit a new version of CruzPlot to CRAN with this change as soon as possible